### PR TITLE
Add slf4j-nop dependency to eliminate startup warning about missing c…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,8 @@ dependencies {
     compile "org.openrndr:openrndr-extensions:$openrndrVersion"
     compile "org.openrndr:openrndr-filter:$openrndrVersion"
     compile "org.openrndr:openrndr-ffmpeg:$openrndrVersion"
+    // replace the following with functional slf4j library when using slf4j
+    compile 'org.slf4j:slf4j-nop:1.7.25'
 }
 
 compileKotlin {


### PR DESCRIPTION
…lass "org.slf4j.impl.StaticLoggerBinder"

When using the existing openrndr-gradle-template and starts the program, one gets the warnings
```SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```

Though it is not a problem really, it still looks a bit ugly, I think
Adding the line `compile 'org.slf4j:slf4j-nop:1.7.25'` in the ‘dependencies’ section of the built.gradle file fixes this.