### PR TITLE
Update gradle wrapper distributionUrl to 4.10-all

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip


### PR DESCRIPTION
OPENRNDR recently upgraded Gradle to 4.10-all to fix an error that was
happening with Gradle 4.6.

This PR updates openrndr-gradle-template to fix the same issue.

See https://github.com/openrndr/openrndr/pull/23
and https://github.com/openrndr/openrndr/pull/25
for further background.